### PR TITLE
Use consistent key value name

### DIFF
--- a/jointech/fishnet/templates/deployment.yaml
+++ b/jointech/fishnet/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
           env:
             - name: KEY
             {{- if .Values.fishnetKey }}
-              value: {{ .Values.cookieSecret.key }}
+              value: {{ .Values.fishnetKey }}
             {{- else }}
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
The key was defined as fishnetKey in the values, but was referenced
as cookieSecret.key in the deployment manifests.